### PR TITLE
fix : n+1 query problem

### DIFF
--- a/src/main/java/whereQR/project/domain/dashboard/CustomDashboardRepositoryImpl.java
+++ b/src/main/java/whereQR/project/domain/dashboard/CustomDashboardRepositoryImpl.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import whereQR.project.domain.dashboard.dto.DashboardSearchCriteria;
+import whereQR.project.domain.file.QFile;
 
 
 import java.util.List;
@@ -22,13 +23,19 @@ public class CustomDashboardRepositoryImpl implements CustomDashboardRepository 
 
     @Override
     public List<Dashboard> findDashboardsByPaginationAndSearch(DashboardSearchCriteria condition, Pageable pageable){
+
+        // Lazy Fetching n+1 problem fix
+        QFile file = QFile.file;
         BooleanBuilder builder = getBooleanBuilder(condition);
+
         return queryFactory
                 .selectFrom(dashboard)
+                .leftJoin(dashboard.images, file)
                 .where(builder)
                 .orderBy(dashboard.createdAt.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
+                .fetchJoin()
                 .fetch();
     }
     @Override


### PR DESCRIPTION
- dashboard와 file의 다대일 관계에서 dashboard 1개당 file 여러개 가능. -> lazy fetching이기에 .getImages를 하는 순간, N+1

문제) 
![image](https://github.com/baek-park/whereQR_Spring_version/assets/74058047/d1fa590e-3ff7-46da-ae27-835526bf1496)

해결과정)
- fetch join
toMany 관계에서는 limit이 이 적용되지 않기에, 이것만으로는 pagination에 적용하기 어려움
- batchsize
한번에 불러올 사이즈, 100으로 설정 -> application yaml 파일에 적용

<img width="888" alt="image" src="https://github.com/baek-park/whereQR_Spring_version/assets/74058047/2c90360d-38cd-49be-8527-cb003dd1823c">
1차 cache에 proxy를 저장하기에 영속성 사용가능. get하면 저장되어있던 객체를 불러오기에 추가쿼리없음
